### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,12 +10,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.7
       - name: Without quotation
-        uses: actions/setup-node@v3.0.0
+        uses: actions/setup-node@v4.0.2
 
       - name: With single quotation
-        uses: 'actions/setup-node@v3.0.0'
+        uses: 'actions/setup-node@v4.0.2'
 
       - name: With double quotation
-        uses: "actions/setup-node@v3.0.0"
+        uses: "actions/setup-node@v4.0.2"

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.7
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
       - uses: kenz/github-actions-version-updater@v0.8.2beta


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.2](https://github.com/actions/setup-node/releases/tag/v4.0.2)** on 2024-02-07T04:51:19Z
